### PR TITLE
fix: consistently use the fm.sh script to ensure all requirements sat…

### DIFF
--- a/tools/sh/bulk_flash
+++ b/tools/sh/bulk_flash
@@ -1,3 +1,3 @@
 # Reprogram flash sectors based on a CSV file
 
-python $FOENIXMGR/FoenixMgr/fnxmgr.py --flash-bulk $1
+$FOENIXMGR/fm.sh --flash-bulk $1

--- a/tools/sh/deref
+++ b/tools/sh/deref
@@ -2,7 +2,7 @@
 # usage: deref {label}
 if [ -z $2 ]
 then
-    python $FOENIXMGR/FoenixMgr/fnxmgr.py --deref $1
+    $FOENIXMGR/fm.sh --deref $1
 else
-    python $FOENIXMGR/FoenixMgr/fnxmgr.py --deref $1 --count $2
+    $FOENIXMGR/fm.sh --deref $1 --count $2
 fi

--- a/tools/sh/dump
+++ b/tools/sh/dump
@@ -3,7 +3,7 @@
 
 if [ -z $2 ]
 then
-    python $FOENIXMGR/FoenixMgr/fnxmgr.py --dump $1
+    $FOENIXMGR/fm.sh --dump $1
 else
-    python $FOENIXMGR/FoenixMgr/fnxmgr.py --dump $1 --count $2
+    $FOENIXMGR/fm.sh --dump $1 --count $2
 fi

--- a/tools/sh/flash
+++ b/tools/sh/flash
@@ -2,7 +2,7 @@
 
 if [ -z $2 ]
 then
-    python $FOENIXMGR/FoenixMgr/fnxmgr.py --flash $1
+    $FOENIXMGR/fm.sh --flash $1
 else
-    python $FOENIXMGR/FoenixMgr/fnxmgr.py --flash $1 --address $2
+    $FOENIXMGR/fm.sh --flash $1 --address $2
 fi

--- a/tools/sh/flash_sector
+++ b/tools/sh/flash_sector
@@ -1,3 +1,3 @@
 # Reprogram an 8KB sector of the flash memory on the Foenix
 
-python $FOENIXMGR/FoenixMgr/fnxmgr.py --target $1 --flash-sector $2 --flash $3
+$FOENIXMGR/fm.sh --target $1 --flash-sector $2 --flash $3

--- a/tools/sh/lookup
+++ b/tools/sh/lookup
@@ -2,7 +2,7 @@
 # usage: lookup {label}
 
 if [ -z $2 ]
-    python $FOENIXMGR/FoenixMgr/fnxmgr.py --lookup $1
+    $FOENIXMGR/fm.sh --lookup $1
 else
-    python $FOENIXMGR/FoenixMgr/fnxmgr.py --lookup $1 --count $2
+    $FOENIXMGR/fm.sh --lookup $1 --count $2
 fi

--- a/tools/sh/pcopy
+++ b/tools/sh/pcopy
@@ -1,4 +1,4 @@
 
 # Copy a file from the PC to the SDCARD on Foenix
 
-python $FOENIXMGR/FoenixMgr/fnxmgr.py --copy $1
+$FOENIXMGR/fm.sh --copy $1

--- a/tools/sh/revision
+++ b/tools/sh/revision
@@ -1,2 +1,2 @@
 # Get the revision code of the Foenix's debug interface
-python $FOENIXMGR/FoenixMgr/fnxmgr.py --revision
+$FOENIXMGR/fm.sh --revision

--- a/tools/sh/runfnx
+++ b/tools/sh/runfnx
@@ -1,2 +1,2 @@
 
-python $FOENIXMGR/FoenixMgr/fnxmgr.py --upload $1
+$FOENIXMGR/fm.sh --upload $1

--- a/tools/sh/runpgx
+++ b/tools/sh/runpgx
@@ -1,4 +1,4 @@
 
 # Upload and run a PGX file on the Foenix
 
-python $FOENIXMGR/FoenixMgr/fnxmgr.py --run-pgx $1
+$FOENIXMGR/fm.sh --run-pgx $1

--- a/tools/sh/runpgz
+++ b/tools/sh/runpgz
@@ -1,4 +1,4 @@
 
 # Upload and run a PGZ file on the Foenix
 
-python $FOENIXMGR/FoenixMgr/fnxmgr.py --run-pgz $1
+$FOENIXMGR/fm.sh --run-pgz $1

--- a/tools/sh/upload
+++ b/tools/sh/upload
@@ -2,7 +2,7 @@
 
 if [ -z $2 ]
 then
-    python $FOENIXMGR/FoenixMgr/fnxmgr.py --binary $1
+    $FOENIXMGR/fm.sh --binary $1
 else
-    python $FOENIXMGR/FoenixMgr/fnxmgr.py --binary $1 --address $2
+    $FOENIXMGR/fm.sh --binary $1 --address $2
 fi

--- a/tools/sh/uploadhex
+++ b/tools/sh/uploadhex
@@ -2,7 +2,7 @@
 
 if [ -z $2 ]
 then
-    python $FOENIXMGR/FoenixMgr/fnxmgr.py --upload $1
+    $FOENIXMGR/fm.sh --upload $1
 else
-    python $FOENIXMGR/FoenixMgr/fnxmgr.py --upload $1 --address $2
+    $FOENIXMGR/fm.sh --upload $1 --address $2
 fi

--- a/tools/sh/uploadsrec
+++ b/tools/sh/uploadsrec
@@ -1,3 +1,3 @@
 # Upload an SREC file to the Foenix
 
-python $FOENIXMGR/FoenixMgr/fnxmgr.py --upload-srec $1
+$FOENIXMGR/fm.sh --upload-srec $1


### PR DESCRIPTION
…isfied

In coco-shelf, the tools/sh commands are copied to coco-shelf/bin and they are also prepended with some environment variables. The problem is that the virtual environment with all the python requirements is not honored. So this PR changes the tools/sh commands to consistently use fm.sh so that the requirements are met for python. I ran across this using a makefile under nitros9 in coco-shelf and module not found errors occurred.