### PR TITLE
Add K2 and JR2 USB keyboard injection

### DIFF
--- a/FoenixMgr/fnxmgr.py
+++ b/FoenixMgr/fnxmgr.py
@@ -1,3 +1,9 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "pyserial",
+# ]
+# ///
 import intelhex
 import wdc
 import foenix
@@ -13,6 +19,8 @@ import pgz
 import pgx
 import csv
 import zlib
+import time
+import keyboard
 
 from serial.tools import list_ports
 
@@ -91,6 +99,45 @@ def revision(port):
             exit_debug(c256)
     finally:
         c256.close()
+
+def inject_keyboard_snapshots(port, snapshots):
+    """Inject optical keyboard snapshots without stopping the running CPU."""
+    c256 = foenix.FoenixDebugPort()
+    try:
+        c256.open(port)
+        for snapshot in snapshots:
+            c256.inject_optical_keyboard_snapshot(snapshot)
+            # The microkernel consumes at most one complete snapshot per video
+            # frame. Keep a release image from replacing its press too early.
+            time.sleep(0.025)
+        if not quiet_mode:
+            print("Injected {} optical keyboard snapshots".format(len(snapshots)))
+    finally:
+        c256.close()
+
+def inject_keyboard_scan_codes(port, scan_codes):
+    """Inject raw PS/2 Set-2 bytes without stopping the running CPU."""
+    c256 = foenix.FoenixDebugPort()
+    try:
+        c256.open(port)
+        c256.inject_keyboard_scan_codes(scan_codes)
+        if not quiet_mode:
+            print("Injected {} raw PS/2 scan bytes".format(len(scan_codes)))
+    finally:
+        c256.close()
+
+def parse_scan_codes(values):
+    """Parse command-line hexadecimal scan-code bytes."""
+    scan_codes = []
+    for value in values:
+        try:
+            scan_code = int(value, 16)
+        except ValueError as error:
+            raise ValueError("invalid scan byte {!r}".format(value)) from error
+        if not 0 <= scan_code <= 0xFF:
+            raise ValueError("scan byte {!r} is outside 00-FF".format(value))
+        scan_codes.append(scan_code)
+    return scan_codes
 
 def upload_binary(port, filename, address):
     """Upload a binary file into the C256 memory."""
@@ -682,6 +729,15 @@ parser.add_argument("--stop", action="store_true", dest="stop",
 parser.add_argument("--start", action="store_true", dest="start",
                     help="Restart the CPU after a STOP (F256 only).")
 
+parser.add_argument("--key", metavar="KEY", dest="keyboard_keys", nargs="+",
+                    help="Inject named keys or single characters through the K2 optical keyboard.")
+
+parser.add_argument("--type", metavar="TEXT", dest="keyboard_text",
+                    help="Type text through the K2 optical keyboard.")
+
+parser.add_argument("--scancodes", metavar="BYTE", dest="keyboard_scan_codes", nargs="+",
+                    help="Inject raw hexadecimal PS/2 Set-2 bytes into the K2/JR2 keyboard FIFO.")
+
 parser.add_argument("--quiet", action="store_true", dest="quiet",
                     help="Suppress some printed messages.")
 
@@ -711,6 +767,29 @@ try:
         elif options.start:
             start_cpu(options.port)
             print("Starting the CPU...")
+
+        elif options.keyboard_keys:
+            try:
+                snapshots = []
+                for key_name in options.keyboard_keys:
+                    snapshots.extend(keyboard.encode_optical_key(key_name))
+            except ValueError as error:
+                parser.error(str(error))
+            inject_keyboard_snapshots(options.port, snapshots)
+
+        elif options.keyboard_text is not None:
+            try:
+                snapshots = keyboard.encode_optical_text(options.keyboard_text)
+            except ValueError as error:
+                parser.error(str(error))
+            inject_keyboard_snapshots(options.port, snapshots)
+
+        elif options.keyboard_scan_codes:
+            try:
+                scan_codes = parse_scan_codes(options.keyboard_scan_codes)
+            except ValueError as error:
+                parser.error(str(error))
+            inject_keyboard_scan_codes(options.port, scan_codes)
 
         elif options.copy_file:
             copy_file(options.port, options.copy_file)

--- a/FoenixMgr/foenix.py
+++ b/FoenixMgr/foenix.py
@@ -7,6 +7,10 @@ import foenix_config
 
 class FoenixDebugPort:
     """Provide the connection to a C256 Foenix debug port."""
+    KEYBOARD_DATA_REGISTER = 0xF01642
+    OPTICAL_KEYBOARD_SNAPSHOT_REGISTER = 0xF01DE0
+    OPTICAL_KEYBOARD_SNAPSHOT_SIZE = 16
+
     connection = None
     status0 = 0
     status1 = 0
@@ -126,6 +130,23 @@ class FoenixDebugPort:
     def read_block(self, address, length):
         """Read a block of data of the specified length from the specified starting address of the C256's memory."""
         return self.transfer(constants.CMD_READ_MEM, address, 0, length)
+
+    def inject_keyboard_scan_codes(self, scan_codes):
+        """Write raw PS/2 Set-2 bytes into the K2/JR2 keyboard FIFO."""
+        for scan_code in scan_codes:
+            if not 0 <= scan_code <= 0xFF:
+                raise ValueError("keyboard scan code must fit in one byte")
+            self.write_block(self.KEYBOARD_DATA_REGISTER, bytes([scan_code]))
+
+    def inject_optical_keyboard_snapshot(self, snapshot):
+        """Stage one complete K2 optical-keyboard matrix image."""
+        if len(snapshot) != self.OPTICAL_KEYBOARD_SNAPSHOT_SIZE:
+            raise ValueError(
+                "optical keyboard snapshot must contain {} bytes, got {}".format(
+                    self.OPTICAL_KEYBOARD_SNAPSHOT_SIZE, len(snapshot)
+                )
+            )
+        self.write_block(self.OPTICAL_KEYBOARD_SNAPSHOT_REGISTER, bytes(snapshot))
 
     def set_boot_source(self, source):
         """Sets whether the system should boot from the RAM LUTs (0) or the Flash LUTs (1)."""

--- a/FoenixMgr/keyboard.py
+++ b/FoenixMgr/keyboard.py
@@ -56,10 +56,26 @@ def _set_optical_key(snapshot, table_index):
 
 
 def _optical_stroke(table_index, shift=False):
+    if shift:
+        shift_only = _empty_optical_snapshot()
+        _set_optical_key(shift_only, _OPTICAL_LEFT_SHIFT_INDEX)
+
+        pressed = bytearray(shift_only)
+        _set_optical_key(pressed, table_index)
+
+        # Shift shares a matrix row with E, S, Z, A, and W. The K2 firmware
+        # scans those key bits before the Shift bit when both change in one
+        # snapshot. Send the modifier transition separately, as a physical
+        # keyboard would, so every shifted key sees Shift already held.
+        return [
+            bytes(shift_only),
+            bytes(pressed),
+            bytes(shift_only),
+            bytes(_empty_optical_snapshot()),
+        ]
+
     pressed = _empty_optical_snapshot()
     _set_optical_key(pressed, table_index)
-    if shift:
-        _set_optical_key(pressed, _OPTICAL_LEFT_SHIFT_INDEX)
     return [bytes(pressed), bytes(_empty_optical_snapshot())]
 
 

--- a/FoenixMgr/keyboard.py
+++ b/FoenixMgr/keyboard.py
@@ -1,0 +1,103 @@
+"""Encode host keys as K2 optical-keyboard matrix snapshots."""
+
+OPTICAL_SNAPSHOT_SIZE = 16
+
+# These are the first 64 entries of the K2 microkernel key table. Each
+# group of eight is a firmware state row. Hardware delivers the rows in reverse
+# order and reverses the column bit numbering.
+_OPTICAL_ASCII_INDEX = {
+    "q": 1, " ": 3, "2": 4, "1": 7, "/": 8, "\t": 9, "'": 13,
+    "]": 14, "=": 15, ",": 16, "[": 17, ";": 18, ".": 19, "l": 21,
+    "p": 22, "-": 23, "n": 24, "o": 25, "k": 26, "m": 27, "0": 28,
+    "j": 29, "i": 30, "9": 31, "v": 32, "u": 33, "h": 34, "b": 35,
+    "8": 36, "g": 37, "y": 38, "7": 39, "x": 40, "t": 41, "f": 42,
+    "c": 43, "6": 44, "d": 45, "r": 46, "5": 47, "e": 49, "s": 50,
+    "z": 51, "4": 52, "a": 53, "w": 54, "3": 55, "\n": 62,
+    "\r": 62,
+}
+
+_OPTICAL_NAMED_INDEX = {
+    "run-stop": 0,
+    "runstop": 0,
+    "pause": 0,
+    "break": 0,
+    "backspace": 6,
+    "tab": 9,
+    "space": 3,
+    "home": 12,
+    "up": 56,
+    "left": 61,
+    "enter": 62,
+}
+
+_SHIFTED = {
+    "!": "1", "@": "2", "#": "3", "$": "4", "%": "5", "^": "6",
+    "&": "7", "*": "8", "(": "9", ")": "0", "_": "-", "+": "=",
+    "{": "[", "}": "]", ":": ";", '"': "'", "<": ",", ">": ".",
+    "?": "/",
+}
+
+_OPTICAL_LEFT_SHIFT_INDEX = 48
+
+
+def _empty_optical_snapshot():
+    snapshot = bytearray(OPTICAL_SNAPSHOT_SIZE)
+    for row in range(8):
+        snapshot[row * 2] = row << 4
+    return snapshot
+
+
+def _set_optical_key(snapshot, table_index):
+    state_row = table_index // 8
+    column = 7 - (table_index % 8)
+    hardware_row = 7 - state_row
+    snapshot[hardware_row * 2] = hardware_row << 4
+    snapshot[hardware_row * 2 + 1] |= 1 << column
+
+
+def _optical_stroke(table_index, shift=False):
+    pressed = _empty_optical_snapshot()
+    _set_optical_key(pressed, table_index)
+    if shift:
+        _set_optical_key(pressed, _OPTICAL_LEFT_SHIFT_INDEX)
+    return [bytes(pressed), bytes(_empty_optical_snapshot())]
+
+
+def encode_optical_character(character):
+    """Return press and release snapshots for one printable character."""
+    if len(character) != 1:
+        raise ValueError("expected one character")
+
+    shift = False
+    if "A" <= character <= "Z":
+        character = character.lower()
+        shift = True
+    elif character in _SHIFTED:
+        character = _SHIFTED[character]
+        shift = True
+
+    try:
+        table_index = _OPTICAL_ASCII_INDEX[character]
+    except KeyError as error:
+        raise ValueError(
+            "character {!r} has no K2 optical-keyboard mapping".format(character)
+        ) from error
+    return _optical_stroke(table_index, shift)
+
+
+def encode_optical_text(text):
+    """Return optical press/release snapshots for every character in text."""
+    snapshots = []
+    for character in text:
+        snapshots.extend(encode_optical_character(character))
+    return snapshots
+
+
+def encode_optical_key(name):
+    """Return press and release snapshots for a named key or character."""
+    table_index = _OPTICAL_NAMED_INDEX.get(name.lower())
+    if table_index is not None:
+        return _optical_stroke(table_index)
+    if len(name) != 1:
+        raise ValueError("unknown key {!r}".format(name))
+    return encode_optical_character(name)

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # FoenixMgr: A command line tool for connecting to the Foenix debug port
 
-FoenixMgr can be used to send binary and Intel HEX files to the Foenix or to read memory from the board. It is a python script that uses the debug port protocol to control the Foenix remotely. Currently, the debug port supports seven actions: stop the processor, restart the processor, read memory, write memory, erase the flash memory, program the flash memory, and retrieve a version code.
+FoenixMgr can be used to send binary and Intel HEX files to the Foenix or to read memory from the board. It is a python script that uses the debug port protocol to control the Foenix remotely. K2 cores can also receive optical-keyboard input through the debug port, while both K2 and JR2 cores support raw PS/2 Set-2 insertion.
 
 ## Installation
 
@@ -42,6 +42,18 @@ To list the available serial ports on your computer:
 
 To get the revision code of the Foenix's debug port:
 `FoenixMgr/fnxmgr --port <port> --revision`
+
+On K2 FPGA cores with USB keyboard injection support, send one or more
+named keys or single characters without stopping the running CPU:
+`FoenixMgr/fnxmgr --port <port> --key run-stop`
+`FoenixMgr/fnxmgr --port <port> --key h e l p enter`
+
+To type a string through the K2 optical-keyboard matrix:
+`FoenixMgr/fnxmgr --port <port> --type "hello world"`
+
+On K2 and JR2 cores exposing the PS/2 keyboard FIFO through the debug I/O aperture, raw
+Set-2 bytes can be supplied in hexadecimal:
+`FoenixMgr/fnxmgr --port <port> --scancodes 1c f0 1c`
 
 To send a hex file:
 `FoenixMgr/fnxmgr --port <port> --upload <hexfile>`
@@ -88,7 +100,9 @@ usage: foenixmgr.zip [-h] [--port PORT] [--list-ports]
                      [--upload-wdc BINARY FILE] [--run-pgz PGZ FILE]
                      [--run-pgx PGX FILE] [--upload-srec SREC FILE]
                      [--boot STRING] [--target STRING]
-                     [--tcp-bridge HOST:PORT] [--stop] [--start] [--quiet]
+                     [--tcp-bridge HOST:PORT] [--stop] [--start]
+                     [--key KEY [KEY ...]] [--type TEXT]
+                     [--scancodes BYTE [BYTE ...]] [--quiet]
 
 Manage the C256 Foenix through its debug port.
 
@@ -134,6 +148,12 @@ optional arguments:
                         serial port
   --stop                Stop the CPU from processing instructions (F256 only).
   --start               Restart the CPU after a STOP (F256 only).
+  --key KEY [KEY ...]   Inject named keys or single characters through the K2
+                        optical keyboard.
+  --type TEXT           Type text through the K2 optical keyboard.
+  --scancodes BYTE [BYTE ...]
+                        Inject raw hexadecimal PS/2 Set-2 bytes into the K2/JR2
+                        keyboard FIFO.
   --quiet               Suppress some printed messages.
 ```
 

--- a/fm.sh
+++ b/fm.sh
@@ -2,6 +2,12 @@
 
 DIR=$(realpath $(dirname "$0"))
 
+# Prefer uv when available. fnxmgr.py carries its lightweight runtime
+# dependency declaration, so uv can provision and launch it directly.
+if command -v uv >/dev/null 2>&1; then
+  exec uv run "$DIR/FoenixMgr/fnxmgr.py" "$@"
+fi
+
 # Detect if python3 or python installed
 if command -v python3 >/dev/null 2>&1; then
   PYTHON_EXEC=python3
@@ -23,5 +29,5 @@ fi
 
 # Launch script in virtual environment.
 source $DIR/.venv/bin/activate
-$PYTHON_EXEC $DIR/FoenixMgr/fnxmgr.py $@
+$PYTHON_EXEC "$DIR/FoenixMgr/fnxmgr.py" "$@"
 deactivate

--- a/tests/test_keyboard.py
+++ b/tests/test_keyboard.py
@@ -17,8 +17,20 @@ class OpticalKeyboardEncodingTests(unittest.TestCase):
         self.assertEqual(released[2:4], bytes([0x10, 0x00]))
 
     def test_uppercase_a_adds_left_shift(self):
-        pressed, _ = keyboard.encode_optical_character("A")
-        self.assertEqual(pressed[2:4], bytes([0x10, 0x84]))
+        shift_down, key_down, key_up, shift_up = keyboard.encode_optical_character("A")
+        self.assertEqual(shift_down[2:4], bytes([0x10, 0x80]))
+        self.assertEqual(key_down[2:4], bytes([0x10, 0x84]))
+        self.assertEqual(key_up[2:4], bytes([0x10, 0x80]))
+        self.assertEqual(shift_up[2:4], bytes([0x10, 0x00]))
+
+    def test_all_uppercase_letters_sequence_shift_before_key(self):
+        for character in "ABCDEFGHIJKLMNOPQRSTUVWXYZ":
+            with self.subTest(character=character):
+                snapshots = keyboard.encode_optical_character(character)
+                self.assertEqual(len(snapshots), 4)
+                self.assertEqual(snapshots[0][3], 0x80)
+                self.assertEqual(snapshots[2][3], 0x80)
+                self.assertEqual(snapshots[3][3], 0x00)
 
     def test_run_stop(self):
         pressed, _ = keyboard.encode_optical_key("run-stop")

--- a/tests/test_keyboard.py
+++ b/tests/test_keyboard.py
@@ -1,0 +1,62 @@
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import call
+from unittest.mock import Mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "FoenixMgr"))
+
+import foenix
+import keyboard
+
+
+class OpticalKeyboardEncodingTests(unittest.TestCase):
+    def test_lowercase_a(self):
+        pressed, released = keyboard.encode_optical_character("a")
+        self.assertEqual(pressed[2:4], bytes([0x10, 0x04]))
+        self.assertEqual(released[2:4], bytes([0x10, 0x00]))
+
+    def test_uppercase_a_adds_left_shift(self):
+        pressed, _ = keyboard.encode_optical_character("A")
+        self.assertEqual(pressed[2:4], bytes([0x10, 0x84]))
+
+    def test_run_stop(self):
+        pressed, _ = keyboard.encode_optical_key("run-stop")
+        self.assertEqual(pressed[14:16], bytes([0x70, 0x80]))
+
+    def test_text_contains_press_and_release_for_each_character(self):
+        self.assertEqual(len(keyboard.encode_optical_text("ab")), 4)
+
+    def test_unknown_key_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "unknown key"):
+            keyboard.encode_optical_key("f13")
+
+
+class KeyboardProtocolTests(unittest.TestCase):
+    def setUp(self):
+        self.port = foenix.FoenixDebugPort()
+        self.port.write_block = Mock()
+
+    def test_optical_snapshot_uses_staging_register(self):
+        snapshot = bytes(range(16))
+        self.port.inject_optical_keyboard_snapshot(snapshot)
+        self.port.write_block.assert_called_once_with(0xF01DE0, snapshot)
+
+    def test_optical_snapshot_requires_exact_size(self):
+        with self.assertRaisesRegex(ValueError, "must contain 16 bytes"):
+            self.port.inject_optical_keyboard_snapshot(bytes(15))
+
+    def test_scan_codes_are_written_one_at_a_time(self):
+        self.port.inject_keyboard_scan_codes([0x1C, 0xF0, 0x1C])
+        self.assertEqual(
+            self.port.write_block.call_args_list,
+            [
+                call(0xF01642, bytes([0x1C])),
+                call(0xF01642, bytes([0xF0])),
+                call(0xF01642, bytes([0x1C])),
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/sh/lookup
+++ b/tools/sh/lookup
@@ -2,6 +2,7 @@
 # usage: lookup {label}
 
 if [ -z $2 ]
+then
     $FOENIXMGR/fm.sh --lookup $1
 else
     $FOENIXMGR/fm.sh --lookup $1 --count $2


### PR DESCRIPTION
## Summary

- add K2 optical-keyboard matrix encoding and atomic snapshot injection
- sequence shifted keys as modifier down, key down, key up, modifier up to match K2 scan ordering
- add K2/JR2 raw PS/2 Set-2 FIFO insertion
- expose the functionality through --key, --type, and --scancodes
- document supported hardware and command examples
- add focused encoding and protocol tests, including all uppercase letters
- retain uv launch support while preserving the upstream Python/venv fallback
- fix the missing then in the lookup shell wrapper

## Validation

- python -m unittest discover -s tests -v (9 tests)
- python -m compileall -q FoenixMgr tests
- bash syntax checks for fm.sh and every tools/sh wrapper
- CLI help smoke test through fm.sh
- live K2 F7 test over USB with HDMI confirmation
- live uppercase A-Z regression: all 26 letters display uppercase after modifier sequencing fix